### PR TITLE
Fix/#52 auditor aware

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -19,6 +19,11 @@ spring:
           predicates:
             - Path=/api/products/**  # /auth/** 경로로 들어오는 요청을 이 라우트로 처리
 
+        - id: order-service
+          uri: lb://order-service
+          predicates:
+            - Path=/api/orders/**
+
         - id: hub-service
           uri: lb://hub-service
           predicates:

--- a/order/src/main/java/com/eleven/logistics/order/common/config/JpaAuditorAware.java
+++ b/order/src/main/java/com/eleven/logistics/order/common/config/JpaAuditorAware.java
@@ -1,22 +1,33 @@
 package com.eleven.logistics.order.common.config;
 
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Configuration;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
 
-@Configuration
-@EnableJpaAuditing
-@RequiredArgsConstructor
+@Slf4j(topic = "Order Service JpaAuditor")
+@Component
 public class JpaAuditorAware implements AuditorAware<String> {
-
-    private final HttpServletRequest request;
 
     @Override
     public Optional<String> getCurrentAuditor() {
-        return Optional.ofNullable(request.getHeader("X-Username"));
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        if (attributes == null) {
+            log.info("RequestAttributes is null");
+
+            // 필요한 정보가 없을 경우 Optional.empty() 를 반환하여 예외 방지.
+            return Optional.empty();
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        String username = request.getHeader("X-Username");
+        log.info("X-Username: {}", username);
+        return Optional.ofNullable(username);
     }
 }

--- a/order/src/main/java/com/eleven/logistics/order/common/config/JpaConfig.java
+++ b/order/src/main/java/com/eleven/logistics/order/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.eleven.logistics.order.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "jpaAuditorAware")
+public class JpaConfig {
+}

--- a/order/src/main/java/com/eleven/logistics/order/domain/entity/BaseTimeEntity.java
+++ b/order/src/main/java/com/eleven/logistics/order/domain/entity/BaseTimeEntity.java
@@ -1,21 +1,20 @@
 package com.eleven.logistics.order.domain.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-/**
- * Auditing Data Class
- * @EntityListeners(AuditingEntityListener.class) 스프링 부트 3.2 부터 생략이 가능하다.
- */
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
     @CreatedDate

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -6,8 +6,8 @@ spring:
     name: order-service
 
   datasource:
-    username: admin
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://localhost:5432/eleven-logistics-order
+    username: eleven-logistics
     password: 1234
   jpa:
     hibernate:

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// msa
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 

--- a/product/src/main/java/com/eleven/logistics/product/TestDataInitializer.java
+++ b/product/src/main/java/com/eleven/logistics/product/TestDataInitializer.java
@@ -22,21 +22,21 @@ public class TestDataInitializer implements CommandLineRunner {
                 .hubId(UUID.randomUUID())
                 .name("notebook")
                 .price(1000000)
-                .quantity(5)
+                .stockQuantity(5)
                 .build();
         Product macbook = Product.builder()
                 .companyId(UUID.randomUUID())
                 .hubId(UUID.randomUUID())
                 .name("macbook")
                 .price(1500000)
-                .quantity(10)
+                .stockQuantity(10)
                 .build();
         Product ipad = Product.builder()
                 .companyId(UUID.randomUUID())
                 .hubId(UUID.randomUUID())
                 .name("ipad")
                 .price(800000)
-                .quantity(20)
+                .stockQuantity(20)
                 .build();
         List<Product> products = List.of(notebook, macbook, ipad);
         repository.saveAll(products);

--- a/product/src/main/java/com/eleven/logistics/product/application/ProductService.java
+++ b/product/src/main/java/com/eleven/logistics/product/application/ProductService.java
@@ -33,7 +33,7 @@ public class ProductService {
                 .hubId(dto.hubId())
                 .name(dto.name())
                 .price(dto.price())
-                .quantity(dto.quantity())
+                .stockQuantity(dto.quantity())
                 .build();
 
         repository.save(product);

--- a/product/src/main/java/com/eleven/logistics/product/application/dto/ResponseDto.java
+++ b/product/src/main/java/com/eleven/logistics/product/application/dto/ResponseDto.java
@@ -29,7 +29,7 @@ public record ResponseDto(
                 .hubId(product.getHubId())
                 .name(product.getName())
                 .price(product.getPrice())
-                .quantity(product.getQuantity())
+                .quantity(product.getStockQuantity())
                 .createdAt(product.getCreatedAt())
                 .updatedAt(product.getUpdatedAt())
                 .build();

--- a/product/src/main/java/com/eleven/logistics/product/application/dto/UpdateDto.java
+++ b/product/src/main/java/com/eleven/logistics/product/application/dto/UpdateDto.java
@@ -1,7 +1,11 @@
 package com.eleven.logistics.product.application.dto;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+
 import java.util.UUID;
 
+@Builder(access = AccessLevel.PRIVATE)
 public record UpdateDto(
         UUID productId,
         UUID companyId,
@@ -10,4 +14,22 @@ public record UpdateDto(
         Integer price,
         Integer quantity
 ) {
+
+    public static UpdateDto create(
+            UUID productId,
+            UUID companyId,
+            UUID hubId,
+            String name,
+            Integer price,
+            Integer quantity
+    ) {
+        return UpdateDto.builder()
+                .productId(productId)
+                .companyId(companyId)
+                .hubId(hubId)
+                .name(name)
+                .price(price)
+                .quantity(quantity)
+                .build();
+    }
 }

--- a/product/src/main/java/com/eleven/logistics/product/common/config/JpaAuditorAware.java
+++ b/product/src/main/java/com/eleven/logistics/product/common/config/JpaAuditorAware.java
@@ -1,22 +1,33 @@
 package com.eleven.logistics.product.common.config;
 
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Configuration;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Optional;
 
-@Configuration
-@EnableJpaAuditing
-@RequiredArgsConstructor
+@Slf4j(topic = "Product Service JpaAuditor")
+@Component
 public class JpaAuditorAware implements AuditorAware<String> {
-
-    private final HttpServletRequest request;
 
     @Override
     public Optional<String> getCurrentAuditor() {
-        return Optional.ofNullable(request.getHeader("X-Username"));
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        if (attributes == null) {
+            log.info("RequestAttributes is null");
+
+            // 필요한 정보가 없을 경우 Optional.empty() 를 반환하여 예외 방지.
+            return Optional.empty();
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        String username = request.getHeader("X-Username");
+        log.info("X-Username: {}", username);
+        return Optional.ofNullable(username);
     }
 }

--- a/product/src/main/java/com/eleven/logistics/product/common/config/JpaConfig.java
+++ b/product/src/main/java/com/eleven/logistics/product/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.eleven.logistics.product.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "jpaAuditorAware")
+public class JpaConfig {
+}

--- a/product/src/main/java/com/eleven/logistics/product/domain/entity/BaseTimeEntity.java
+++ b/product/src/main/java/com/eleven/logistics/product/domain/entity/BaseTimeEntity.java
@@ -1,21 +1,25 @@
 package com.eleven.logistics.product.domain.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 /**
  * Auditing Data Class
  * @EntityListeners(AuditingEntityListener.class) 스프링 부트 3.2 부터 생략이 가능하다.
+ * AuditorAware 를 사용할 경우 명시적으로 추가해야 사용자 정보 추적이 가능하다.
  */
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
     @CreatedDate

--- a/product/src/main/java/com/eleven/logistics/product/domain/entity/Product.java
+++ b/product/src/main/java/com/eleven/logistics/product/domain/entity/Product.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 @Table(name = "p_product")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Product extends BaseTimeEntity {
 
     @Id
@@ -27,15 +26,16 @@ public class Product extends BaseTimeEntity {
 
     private int price;
 
-    private int quantity;
+    private int stockQuantity;
 
+    // TODO: 튜터님 깃 허브 보고 생성 메서드나 업데이트 메서드 수정할 것
     @Builder
-    private Product(UUID companyId, UUID hubId, String name, int price, int quantity) {
+    private Product(UUID companyId, UUID hubId, String name, int price, int stockQuantity) {
         this.companyId = companyId;
         this.hubId = hubId;
         this.name = name;
         this.price = price;
-        this.quantity = quantity;
+        this.stockQuantity = stockQuantity;
     }
 
     public void updateOf(UUID companyId, UUID hubId, String name, int price, int quantity) {
@@ -43,11 +43,11 @@ public class Product extends BaseTimeEntity {
         this.hubId = hubId;
         this.name = name;
         this.price = price;
-        this.quantity = quantity;
+        this.stockQuantity = quantity;
     }
 
     public void reduceQuantity(int quantity) {
-        this.quantity -= quantity;
+        this.stockQuantity -= quantity;
     }
 
     public void deleteOf(String deletedBy) {

--- a/product/src/main/java/com/eleven/logistics/product/domain/exception/ProductErrorCode.java
+++ b/product/src/main/java/com/eleven/logistics/product/domain/exception/ProductErrorCode.java
@@ -14,7 +14,6 @@ public enum ProductErrorCode implements ErrorCode {
     NO_KEYWORD(HttpStatus.BAD_REQUEST, "검색어를 입력해주세요.")
     ;
 
-
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/product/src/main/java/com/eleven/logistics/product/domain/repository/ProductRepository.java
+++ b/product/src/main/java/com/eleven/logistics/product/domain/repository/ProductRepository.java
@@ -9,5 +9,5 @@ public interface ProductRepository {
 
     Product save(Product product);
 
-    Optional<Product> findByProductIdAndDeletedAtIsNull(UUID id);
+    Optional<Product> findByProductIdAndDeletedAtIsNull(UUID productId);
 }

--- a/product/src/main/java/com/eleven/logistics/product/infrastructure/ProductRepositoryCustom.java
+++ b/product/src/main/java/com/eleven/logistics/product/infrastructure/ProductRepositoryCustom.java
@@ -7,7 +7,6 @@ import com.eleven.logistics.product.common.resolver.dto.PageResponseDto;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -17,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.eleven.logistics.product.domain.entity.QProduct.product;
-import static com.eleven.logistics.product.domain.exception.ProductErrorCode.NO_KEYWORD;
 import static com.eleven.logistics.product.domain.exception.ProductErrorCode.ORDER_BY_NOT_FOUND;
 
 @Repository
@@ -28,11 +26,11 @@ public class ProductRepositoryCustom {
 
     /**
      * 상품 목록 조회
-     * page, order
+     * 페이징, 정렬
      */
     public PageResponseDto<ResponseDto> readProducts(PageRequestDto dto) {
-        List<ResponseDto> content = getProductList(dto);
-        long total = getTotalCount();
+        List<ResponseDto> content = getProductList(null, dto);
+        long total = getTotalCount(null);
 
         return new PageResponseDto<>(content, total);
     }
@@ -42,35 +40,12 @@ public class ProductRepositoryCustom {
      */
     public PageResponseDto<ResponseDto> retrieveProducts(String keyword, PageRequestDto dto) {
         List<ResponseDto> content = getProductList(keyword, dto);
-        long total = getTotalCount();
+        long total = getTotalCount(keyword);
         return new PageResponseDto<>(content, total);
     }
 
     /**
-     * 페이징 조회 메서드
-     */
-    private List<ResponseDto> getProductList(PageRequestDto dto) {
-        return jpaQueryFactory
-                .select(Projections.constructor(ResponseDto.class,
-                        product.productId,
-                        product.companyId,
-                        product.hubId,
-                        product.name,
-                        product.price,
-                        product.quantity,
-                        product.createdAt,
-                        product.updatedAt
-                        ))
-                .from(product)
-                .where(getWhereConditions())
-                .offset(dto.getFirstIndex())
-                .limit(dto.size())
-                .orderBy(getOrderConditions(dto))
-                .fetch();
-    }
-
-    /**
-     * 검색 메서드
+     * 페이징 + 검색 메서드
      */
     private List<ResponseDto> getProductList(String keyword, PageRequestDto dto) {
         return jpaQueryFactory
@@ -80,7 +55,7 @@ public class ProductRepositoryCustom {
                         product.hubId,
                         product.name,
                         product.price,
-                        product.quantity,
+                        product.stockQuantity,
                         product.createdAt,
                         product.updatedAt
                 ))
@@ -95,39 +70,29 @@ public class ProductRepositoryCustom {
     /**
      * 전체 데이터 수 조회
      */
-    private long getTotalCount() {
+    private long getTotalCount(String keyword) {
         return Optional.ofNullable(jpaQueryFactory
                         .select(product.count())
                         .from(product)
-                        .where(getWhereConditions())
+                        .where(getWhereConditions(keyword))
                         .fetchOne()
                 )
                 .orElse(0L);
     }
 
     /**
-     * 조회 조건: deletedAt
-     */
-    private BooleanBuilder getWhereConditions() {
-        BooleanBuilder builder = new BooleanBuilder();
-
-        // soft delete 정책을 사용한다.
-        return builder.and(product.deletedAt.isNull());
-    }
-
-    /**
-     * 조회 조건: deletedAt, keyword
+     * 조회 조건
      */
     private BooleanBuilder getWhereConditions(String keyword) {
-        if (!StringUtils.hasText(keyword)) {
-            throw new CustomException(NO_KEYWORD);
-        }
-
         BooleanBuilder builder = new BooleanBuilder();
+
+        // soft delete 정책 적용
         builder.and(product.deletedAt.isNull());
 
-        BooleanExpression keywordCondition = product.name.containsIgnoreCase(keyword);
-        builder.and(keywordCondition);
+        // keyword 가 있을 경우 검색 조건 추가
+        if (StringUtils.hasText(keyword)) {
+            builder.and(product.name.containsIgnoreCase(keyword));
+        }
 
         return builder;
     }
@@ -136,9 +101,13 @@ public class ProductRepositoryCustom {
      * 정렬 조건
      */
     private OrderSpecifier<?> getOrderConditions(PageRequestDto dto) {
-        String order = dto.orderBy();
+        String orderBy = dto.orderBy().toLowerCase();
 
-        return switch (order) {
+        if (!StringUtils.hasText(orderBy)) {
+            return product.createdAt.desc();
+        }
+
+        return switch (orderBy) {
             case "desc" -> product.createdAt.desc();
             case "asc" -> product.createdAt.asc();
             default -> throw new CustomException(ORDER_BY_NOT_FOUND);

--- a/product/src/main/java/com/eleven/logistics/product/presentation/dto/UpdateRequestDto.java
+++ b/product/src/main/java/com/eleven/logistics/product/presentation/dto/UpdateRequestDto.java
@@ -26,7 +26,7 @@ public record UpdateRequestDto(
         Integer quantity
 ) {
     public UpdateDto withId(UUID productId) {
-        return new UpdateDto(
+        return UpdateDto.create(
                 productId,
                 this.companyId,
                 this.hubId,

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -6,12 +6,19 @@ spring:
     name: product-service
 
   datasource:
-    username: admin
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://localhost:5432/eleven-logistics-product
+    username: eleven-logistics
     password: 1234
+    driver-class-name: org.postgresql.Driver
+
   jpa:
     hibernate:
       ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 eureka:
   client:

--- a/product/src/test/java/com/eleven/logistics/product/ProductApplicationTests.java
+++ b/product/src/test/java/com/eleven/logistics/product/ProductApplicationTests.java
@@ -4,8 +4,6 @@ import com.eleven.logistics.product.presentation.dto.CreateRequestDto;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -19,8 +17,6 @@ import java.util.UUID;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 class ProductApplicationTests {
-
-	private static final Logger log = LoggerFactory.getLogger(ProductApplicationTests.class);
 
 	private static final PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:16.3");
 

--- a/product/src/test/java/com/eleven/logistics/product/application/dto/ResponseDtoJsonTest.java
+++ b/product/src/test/java/com/eleven/logistics/product/application/dto/ResponseDtoJsonTest.java
@@ -20,7 +20,8 @@ class ResponseDtoJsonTest {
 
     @Test
     @DisplayName("응답 객체 직렬화 테스트")
-    void toDto() throws IOException {
+    void toJson() throws IOException {
+        // given
         var product = new ResponseDto(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
@@ -32,8 +33,10 @@ class ResponseDtoJsonTest {
                 LocalDateTime.of(2025, 3, 17, 13, 1, 2)
         );
 
+        // when
         var jsonContent = json.write(product);
 
+        // then
         // UUID, LocalDateTime 등의 객체는 비교 시 toString()으로 변환해 주어야 한다.
         assertThat(jsonContent).extractingJsonPathStringValue("@.productId")
                 .isEqualTo(product.productId().toString());

--- a/product/src/test/java/com/eleven/logistics/product/presentation/ProductControllerMvcTest.java
+++ b/product/src/test/java/com/eleven/logistics/product/presentation/ProductControllerMvcTest.java
@@ -42,10 +42,65 @@ class ProductControllerMvcTest {
 
     UUID[] randomId;
 
+    @Test
+    @DisplayName("상품 생성 요청 성공 테스트")
+    void createProduct() throws JsonProcessingException {
+        UUID productId = UUID.randomUUID();
+        var createRequestProduct = new CreateRequestDto(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "product1",
+                10000,
+                10
+        );
+
+        var createRequest = objectMapper.writeValueAsString(createRequestProduct);
+
+        given(productService.createProduct(any(CreateDto.class)))
+                .willReturn(productId);
+
+        // when & then
+        assertThat(mvc.post().uri("/api/products")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createRequest)
+        ).hasStatus(HttpStatus.CREATED)
+                .hasHeader("Location", "/api/products/" + productId);
+
+    }
+
+    @Test
+    @DisplayName("요청한 상품이 없으면 404 NotFound")
+    void readProduct_ById_not_found() {
+        UUID productId = UUID.randomUUID();
+        given(productService.readProduct(productId))
+                .willThrow(new CustomException(PRODUCT_NOT_FOUND));
+
+        // when & then
+        assertThat(mvc.get().uri("/api/products/" + productId)
+                .accept(MediaType.APPLICATION_JSON)
+        ).hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("상품 상세 조회")
+    void readProductById() {
+        given(productService.readProduct(randomId[0]))
+                .willReturn(dtos[0]);
+
+        // when & then
+        assertThat(mvc.get().uri("/api/products/" + randomId[0])
+                .accept(MediaType.APPLICATION_JSON)
+        ).hasStatusOk();
+    }
+
+    @Test
+    @DisplayName("상품 목록 조회")
+    void retreiveProducts() {}
+
     @BeforeEach
     void setUp() {
         randomId = new UUID[9];
-        for (int i = 0; i < 9; i++) {
+        for (int i = 0; i < randomId.length; i++) {
             randomId[i] = UUID.randomUUID();
         }
         dtos = Arrays.array(
@@ -82,59 +137,4 @@ class ProductControllerMvcTest {
 
         );
     }
-
-    @Test
-    @DisplayName("상품 생성 요청 성공 테스트")
-    void createProduct() throws JsonProcessingException {
-        UUID productId = UUID.randomUUID();
-        var createRequestProduct = new CreateRequestDto(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                "product1",
-                10000,
-                10
-        );
-
-        var createRequest = objectMapper.writeValueAsString(createRequestProduct);
-
-        given(productService.createProduct(any(CreateDto.class)))
-                .willReturn(productId);
-
-        // when & then
-        assertThat(mvc.post().uri("/api/products")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(createRequest)
-        ).hasStatus(HttpStatus.CREATED)
-                .hasHeader("Location", "/api/products/" + productId);
-
-    }
-
-    @Test
-    @DisplayName("요청한 상품이 없으면 404 NotFound")
-    void readProduct_ById_not_found() throws Exception {
-        UUID productId = UUID.randomUUID();
-        given(productService.readProduct(productId))
-                .willThrow(new CustomException(PRODUCT_NOT_FOUND));
-
-        // when & then
-        assertThat(mvc.get().uri("/api/products/" + productId)
-                .accept(MediaType.APPLICATION_JSON)
-        ).hasStatus(HttpStatus.NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("상품 상세 조회")
-    void readProductById() {
-        given(productService.readProduct(randomId[0]))
-                .willReturn(dtos[0]);
-
-        // when & then
-        assertThat(mvc.get().uri("/api/products/" + randomId[0])
-                .accept(MediaType.APPLICATION_JSON)
-        ).hasStatusOk();
-    }
-
-    @Test
-    @DisplayName("상품 목록 조회")
-    void retreiveProduct() {}
 }

--- a/product/src/test/java/com/eleven/logistics/product/presentation/dto/CreateRequestDtoJsonTest.java
+++ b/product/src/test/java/com/eleven/logistics/product/presentation/dto/CreateRequestDtoJsonTest.java
@@ -18,8 +18,9 @@ class CreateRequestDtoJsonTest {
     private JacksonTester<CreateRequestDto> json;
 
     @Test
-    @DisplayName("요청 객체 역직렬화 테스트")
+    @DisplayName("요청 데이터 역직렬화 테스트")
     void deserialize() throws IOException {
+        // given
         var content = """
                 {
                     "companyId": "a858fb2e-b6c6-41c6-8c6c-98a8cadfc9b8",
@@ -29,6 +30,8 @@ class CreateRequestDtoJsonTest {
                     "quantity": 10
                 }
                 """;
+
+        // when & then
         assertThat(json.parse(content))
                 .usingRecursiveComparison()
                 .isEqualTo(new CreateRequestDto(

--- a/product/src/test/java/com/eleven/logistics/product/presentation/dto/CreateRequestDtoValidationTest.java
+++ b/product/src/test/java/com/eleven/logistics/product/presentation/dto/CreateRequestDtoValidationTest.java
@@ -29,7 +29,8 @@ class CreateRequestDtoValidationTest {
 
     @Test
     @DisplayName("유효한 값으로 생성")
-    void validateCompanyIdNotNull() {
+    void validate() {
+        // given
         var product = new CreateRequestDto(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
@@ -37,14 +38,18 @@ class CreateRequestDtoValidationTest {
                 10000,
                 10
         );
+
+        // when
         Set<ConstraintViolation<CreateRequestDto>> violations = validator.validate(product);
 
+        // then
         assertThat(violations).isEmpty();
     }
 
     @Test
     @DisplayName("유효하지 않은 company_id 값으로 생성")
     void validateCompanyIdNull() {
+        // given
         var product = new CreateRequestDto(
                 null,
                 UUID.randomUUID(),
@@ -53,7 +58,10 @@ class CreateRequestDtoValidationTest {
                 1
         );
 
+        // when
         Set<ConstraintViolation<CreateRequestDto>> violations = validator.validate(product);
+
+        // then
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage())
                 .isEqualTo("company_id 는 필수 항목입니다.");


### PR DESCRIPTION
## 💡 이슈
resolve #52 

## 🤩 개요
JpaAuditing 적용이 안 되던 문제..
스프링 부트 3.2 부터 audit 적용 필드가 있는 클래스에 @EntityListeners(AuditingEntityListener.class)를 생략해도 되어 생략했으나
createdBy 를 적용하기 위해 AuditorAware를 구현하면 사용자 추적을 위해 명시적으로 추가해야 함.

## 🧑‍💻 작업 사항
BaseEntity 클래스에 @EntityListeners(AuditingEntityListener.class) 를 적용하고 AuditorAware 도 일부 수정
product, order service에 DB 공통 사항 추가 

## 📖 참고 사항
gateway 에 order-service 경로 등록
AuditorAware 구현 시 HttpServletRequest를 주입 받으면 헤더 정보를 가져 오지 못해 ServletRequestAttributes 로 변경
