### PR TITLE
Feat/#69 delivery-service create api 분리

### DIFF
--- a/delivery/src/main/java/com/eleven/logistics/delivery/application/service/DeliveryService.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/application/service/DeliveryService.java
@@ -1,5 +1,8 @@
 package com.eleven.logistics.delivery.application.service;
 
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRequest;
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRouteRequest;
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRouteResponse;
 import com.eleven.logistics.delivery.presentation.dtos.DeliveryResponse;
 import com.eleven.logistics.delivery.presentation.dtos.DeliveryRouteResponse;
 import com.eleven.logistics.delivery.domain.entity.Delivery;
@@ -7,12 +10,13 @@ import com.eleven.logistics.delivery.domain.entity.DeliveryRoute;
 import com.eleven.logistics.delivery.domain.entity.DeliveryStatus;
 import com.eleven.logistics.delivery.domain.entity.RouteStatus;
 import com.eleven.logistics.delivery.domain.repository.DeliveryRepository;
+import com.eleven.logistics.delivery.presentation.dtos.UpdateDeliveryRouteRequest;
 import com.eleven.logistics.delivery.util.PagingUtil;
-import com.eleven.logistics.delivery.presentation.dtos.DeliveryRequest;
-import com.eleven.logistics.delivery.presentation.dtos.DeliveryRouteRequest;
 import com.eleven.logistics.delivery.presentation.dtos.UpdateDeliveryRequest;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,13 +29,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryService {
 
   private final DeliveryRepository deliveryRepository;
+  private final EntityManager em;
+
+  // 배송 조회
+  public DeliveryResponse getDelivery(UUID deliveryId) {
+    Delivery delivery = deliveryRepository.findById(deliveryId)
+        .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
+
+    return new DeliveryResponse(delivery);
+  }
+
+  //배송 경로 조회(특정 배송의 모든 경로)
+  public List<DeliveryRouteResponse> getDeliveryRoutes(UUID deliveryId) {
+    Delivery delivery = deliveryRepository.findById(deliveryId)
+        .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
+
+    return delivery.getDeliveryRoutes().stream()
+        .map(DeliveryRouteResponse::new)
+        .toList();
+  }
 
   // 배송 검색 조회
   public Page<DeliveryResponse> searchDeliveries(
       DeliveryStatus status, UUID orderId, Pageable pageable
   ) {
-    // TODO : 사용자 권한 체크 검증로직 추가
-
     Pageable deliveryPages = PagingUtil.adjustPageable(pageable);
     return deliveryRepository.findByDeliveryStatusAndOrderId(status, orderId, deliveryPages)
         .map(DeliveryResponse::new);
@@ -41,33 +62,55 @@ public class DeliveryService {
   public Page<DeliveryRouteResponse> searchDeliveryRoutes(
       UUID deliveryId, RouteStatus status, Pageable pageable
   ) {
-    // TODO : 사용자 권한 체크 검증로직 추가
-
     Pageable routePages = PagingUtil.adjustPageable(pageable);
     return deliveryRepository.findRoutesByDeliveryIdAndRouteStatus(deliveryId, status, routePages)
         .map(DeliveryRouteResponse::new);
   }
 
-  // 배송 및 배송경로 생성
+  // 배송 생성
   @Transactional
-  public DeliveryResponse createDelivery(DeliveryRequest deliveryDto,
-      List<DeliveryRouteRequest> routeDtos
+  public DeliveryResponse createDelivery(CreateDeliveryRequest request) {
+    Delivery delivery = deliveryRepository.save(new Delivery(request));
+
+    deliveryRepository.save(delivery);
+    delivery.updateCreatedBy(delivery.getCreatedBy());
+
+    return new DeliveryResponse(delivery);
+  }
+
+  // 배송 경로 생성
+  @Transactional
+  public List<CreateDeliveryRouteResponse> createRoute(
+      UUID deliveryId, List<CreateDeliveryRouteRequest> routeDtos
   ) {
     if (routeDtos == null || routeDtos.isEmpty()) {
       throw new IllegalArgumentException(
           "At least one route must be provided when creating a delivery");
     }
 
-    Delivery delivery = new Delivery(deliveryDto);
+    Delivery delivery = deliveryRepository.findById(deliveryId)
+        .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
 
-    for (DeliveryRouteRequest routeDto : routeDtos) {
+    // 기존 경로 개수 저장
+    int existingRouteCount = delivery.getRoutes().size();
+
+    // DeliveryRoute 객체 생성 및 Delivery에 추가
+    routeDtos.forEach(routeDto -> {
       DeliveryRoute route = new DeliveryRoute(delivery, routeDto);
       delivery.addRoute(route);
-    }
+      route.updateCreatedBy(delivery.getCreatedBy());
+    });
 
     deliveryRepository.save(delivery);
-    delivery.updateCreatedBy(delivery.getCreatedBy());
-    return new DeliveryResponse(delivery);
+
+    // 저장된 routes에서 새로 추가된 경로만 추출
+    List<DeliveryRoute> savedRoutes = delivery.getRoutes().subList(
+        existingRouteCount, delivery.getRoutes().size()
+    );
+
+    return savedRoutes.stream()
+        .map(CreateDeliveryRouteResponse::new)
+        .collect(Collectors.toList());
   }
 
   // 배송 상태 변경
@@ -76,8 +119,10 @@ public class DeliveryService {
   ) {
     Delivery delivery = deliveryRepository.findById(deliveryId)
         .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
+
     delivery.updateStatus(status);
     delivery.updateModificationInfo(delivery.getUpdatedBy());
+
     return new DeliveryResponse(delivery);
   }
 
@@ -86,10 +131,9 @@ public class DeliveryService {
   public DeliveryRouteResponse updateRouteStatus(UUID deliveryId, UUID routeId,
       RouteStatus status, int actualDistance, int actualTime
   ) {
-    // TODO : 사용자 권한 체크 검증로직 추가
-
     Delivery delivery = deliveryRepository.findById(deliveryId)
         .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
+
     DeliveryRoute route = delivery.getDeliveryRoutes().stream()
         .filter(r -> r.getId().equals(routeId))
         .findFirst()
@@ -97,14 +141,13 @@ public class DeliveryService {
 
     route.updateStatus(status, actualDistance, actualTime);
     route.updateCreatedBy(delivery.getCreatedBy());
+
     return new DeliveryRouteResponse(route);
   }
 
   // 배송 수정
   @Transactional
   public DeliveryResponse updateDelivery(UUID deliveryId, UpdateDeliveryRequest request) {
-    // TODO : 사용자 권한 체크 검증로직 추가
-
     Delivery delivery = deliveryRepository.findById(deliveryId)
         .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
 
@@ -118,10 +161,8 @@ public class DeliveryService {
   // 배송경로 전체 수정
   @Transactional
   public DeliveryRouteResponse updateRoute(UUID deliveryId, UUID routeId,
-      DeliveryRouteRequest routeDto
+      UpdateDeliveryRouteRequest routeDto
   ) {
-    // TODO : 사용자 권한 체크 검증로직 추가
-
     Delivery delivery = deliveryRepository.findById(deliveryId)
         .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
 
@@ -163,22 +204,5 @@ public class DeliveryService {
 
     delivery.updateDeletionInfo(delivery.getDeletedBy());
   }
-
-  // 배송 조회
-  public DeliveryResponse getDelivery(UUID deliveryId) {
-    Delivery delivery = deliveryRepository.findById(deliveryId)
-        .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
-    return new DeliveryResponse(delivery);
-  }
-
-  //배송 경로 조회(특정 배송의 모든 경로)
-  public List<DeliveryRouteResponse> getDeliveryRoutes(UUID deliveryId) {
-    Delivery delivery = deliveryRepository.findById(deliveryId)
-        .orElseThrow(() -> new IllegalArgumentException("Delivery not found"));
-    return delivery.getDeliveryRoutes().stream()
-        .map(DeliveryRouteResponse::new)
-        .toList();
-  }
-
 
 }

--- a/delivery/src/main/java/com/eleven/logistics/delivery/domain/entity/Delivery.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/domain/entity/Delivery.java
@@ -1,6 +1,6 @@
 package com.eleven.logistics.delivery.domain.entity;
 
-import com.eleven.logistics.delivery.presentation.dtos.DeliveryRequest;
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRequest;
 import com.eleven.logistics.delivery.presentation.dtos.UpdateDeliveryRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -59,7 +59,7 @@ public class Delivery extends Timestamped {
   @OneToMany(mappedBy = "delivery", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<DeliveryRoute> deliveryRoutes = new ArrayList<>();
 
-  public Delivery(DeliveryRequest request) {
+  public Delivery(CreateDeliveryRequest request) {
     this.orderId = request.getOrderId();
     this.departureHubId = request.getDepartureHubId();
     this.destinationHubId = request.getDestinationHubId();
@@ -84,5 +84,9 @@ public class Delivery extends Timestamped {
   public void addRoute(DeliveryRoute route) {
     this.deliveryRoutes.add(route);
     route.assignDelivery(this);
+  }
+
+  public List<DeliveryRoute> getRoutes() {
+    return deliveryRoutes;
   }
 }

--- a/delivery/src/main/java/com/eleven/logistics/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/domain/entity/DeliveryRoute.java
@@ -1,6 +1,7 @@
 package com.eleven.logistics.delivery.domain.entity;
 
-import com.eleven.logistics.delivery.presentation.dtos.DeliveryRouteRequest;
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRouteRequest;
+import com.eleven.logistics.delivery.presentation.dtos.UpdateDeliveryRouteRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -33,7 +34,7 @@ public class DeliveryRoute extends Timestamped {
   @JoinColumn(name = "delivery_id", nullable = false)
   private Delivery delivery;
 
-  @Column(name = "delivery_person_id", nullable = false)
+  @Column(name = "delivery_person_id")
   private UUID deliveryPersonId;
 
   @Column(name = "sequence", nullable = false)
@@ -61,9 +62,8 @@ public class DeliveryRoute extends Timestamped {
   @Enumerated(EnumType.STRING)
   private RouteStatus routeStatus;
 
-  public DeliveryRoute(Delivery delivery, DeliveryRouteRequest routeDto) {
+  public DeliveryRoute(Delivery delivery, CreateDeliveryRouteRequest routeDto) {
     this.delivery = delivery;
-    this.deliveryPersonId = routeDto.getDeliveryPersonId();
     this.sequence = routeDto.getSequence();
     this.departureHubId = routeDto.getDepartureHubId();
     this.arrivalHubId = routeDto.getArrivalHubId();
@@ -74,13 +74,14 @@ public class DeliveryRoute extends Timestamped {
     this.actualTime = 0;
   }
 
-  public void updateRoute(DeliveryRouteRequest routeDto) {
+  public void updateRoute(UpdateDeliveryRouteRequest routeDto) {
     this.deliveryPersonId = routeDto.getDeliveryPersonId();
     this.sequence = routeDto.getSequence();
     this.departureHubId = routeDto.getDepartureHubId();
     this.arrivalHubId = routeDto.getArrivalHubId();
-    this.expectedDistance = routeDto.getExpectedDistance();
-    this.expectedTime = routeDto.getExpectedTime();
+    this.actualDistance = routeDto.getDistance();
+    this.actualTime = routeDto.getTime();
+    this.routeStatus = routeDto.getRouteStatus();
   }
 
   public void updateStatus(RouteStatus status, int actualDistance, int actualTime) {

--- a/delivery/src/main/java/com/eleven/logistics/delivery/presentation/controller/DeliveryController.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/presentation/controller/DeliveryController.java
@@ -1,13 +1,15 @@
 package com.eleven.logistics.delivery.presentation.controller;
 
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRouteRequest;
+import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRouteResponse;
 import com.eleven.logistics.delivery.presentation.dtos.DeliveryResponse;
 import com.eleven.logistics.delivery.application.service.DeliveryService;
 import com.eleven.logistics.delivery.presentation.dtos.DeliveryRouteResponse;
 import com.eleven.logistics.delivery.domain.entity.DeliveryStatus;
 import com.eleven.logistics.delivery.domain.entity.RouteStatus;
 import com.eleven.logistics.delivery.presentation.dtos.CreateDeliveryRequest;
-import com.eleven.logistics.delivery.presentation.dtos.DeliveryRouteRequest;
 import com.eleven.logistics.delivery.presentation.dtos.UpdateDeliveryRequest;
+import com.eleven.logistics.delivery.presentation.dtos.UpdateDeliveryRouteRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -73,15 +75,22 @@ public class DeliveryController {
     return ResponseEntity.ok(result);
   }
 
-  // 배송 및 배송경로 생성
+  // 배송 생성
   @PostMapping
   public ResponseEntity<DeliveryResponse> createDelivery(
-      @RequestBody CreateDeliveryRequest requestDto
+      @Valid @RequestBody CreateDeliveryRequest request
   ) {
-    DeliveryResponse response = deliveryService.createDelivery(
-        requestDto.toDeliveryRequestDto(),
-        requestDto.getRouteDtos()
-    );
+    DeliveryResponse response = deliveryService.createDelivery(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  // 배송 경로 생성
+  @PostMapping("/{deliveryId}/routes")
+  public ResponseEntity<List<CreateDeliveryRouteResponse>> createRoute(
+      @PathVariable UUID deliveryId,
+      @Valid @RequestBody List<CreateDeliveryRouteRequest> routeDtos
+      ) {
+    List<CreateDeliveryRouteResponse> response = deliveryService.createRoute(deliveryId, routeDtos);
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -133,7 +142,7 @@ public class DeliveryController {
   public ResponseEntity<DeliveryRouteResponse> updateRoute(
       @PathVariable UUID deliveryId,
       @PathVariable UUID routeId,
-      @RequestBody DeliveryRouteRequest routeDto
+      @RequestBody UpdateDeliveryRouteRequest routeDto
   ) {
     DeliveryRouteResponse response = deliveryService.updateRoute(deliveryId, routeId, routeDto);
     return ResponseEntity.status(HttpStatus.OK).body(response);

--- a/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/CreateDeliveryRequest.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/CreateDeliveryRequest.java
@@ -1,7 +1,6 @@
 package com.eleven.logistics.delivery.presentation.dtos;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -32,17 +31,4 @@ public class CreateDeliveryRequest {
 
   @NotNull
   private UUID companyDeliveryPersonId;
-
-  private List<DeliveryRouteRequest> routes;
-
-  public DeliveryRequest toDeliveryRequestDto() {
-    return new DeliveryRequest(orderId, departureHubId, destinationHubId,
-        deliveryAddress, receiver, receiverSnsId,
-        companyDeliveryPersonId);
-  }
-
-  public List<DeliveryRouteRequest> getRouteDtos() {
-    return routes;
-  }
-
 }

--- a/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/CreateDeliveryRouteRequest.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/CreateDeliveryRouteRequest.java
@@ -9,26 +9,23 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class DeliveryRequest {
+public class CreateDeliveryRouteRequest {
 
   @NotNull
-  private UUID orderId;
+  private UUID deliveryId;
+
+  private int sequence;
 
   @NotNull
   private UUID departureHubId;
 
   @NotNull
-  private UUID destinationHubId;
+  private UUID arrivalHubId;
 
   @NotNull
-  private String deliveryAddress;
+  private int expectedDistance;
 
   @NotNull
-  private String receiver;
+  private int expectedTime;
 
-  @NotNull
-  private UUID receiverSnsId;
-
-  @NotNull
-  private UUID companyDeliveryPersonId;
 }

--- a/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/CreateDeliveryRouteResponse.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/CreateDeliveryRouteResponse.java
@@ -1,0 +1,34 @@
+package com.eleven.logistics.delivery.presentation.dtos;
+
+import com.eleven.logistics.delivery.domain.entity.DeliveryRoute;
+import com.eleven.logistics.delivery.domain.entity.RouteStatus;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateDeliveryRouteResponse {
+
+  private UUID id;
+  private UUID deliveryId;
+  private int sequence;
+  private UUID departureHubId;
+  private UUID arrivalHubId;
+  private int expectedDistance;
+  private int expectedTime;
+  private RouteStatus routeStatus;
+
+  public CreateDeliveryRouteResponse(DeliveryRoute route) {
+    this.id = route.getId();
+    this.deliveryId = route.getDelivery().getId();
+    this.sequence = route.getSequence();
+    this.departureHubId = route.getDepartureHubId();
+    this.arrivalHubId = route.getArrivalHubId();
+    this.expectedDistance = route.getExpectedDistance();
+    this.expectedTime = route.getExpectedTime();
+    this.routeStatus = route.getRouteStatus();
+  }
+}

--- a/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/UpdateDeliveryRouteRequest.java
+++ b/delivery/src/main/java/com/eleven/logistics/delivery/presentation/dtos/UpdateDeliveryRouteRequest.java
@@ -1,5 +1,6 @@
 package com.eleven.logistics.delivery.presentation.dtos;
 
+import com.eleven.logistics.delivery.domain.entity.RouteStatus;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class DeliveryRouteRequest {
+public class UpdateDeliveryRouteRequest {
 
   @NotNull
   private UUID deliveryPersonId;
@@ -22,9 +23,9 @@ public class DeliveryRouteRequest {
   @NotNull
   private UUID arrivalHubId;
 
-  @NotNull
-  private int expectedDistance;
+  private int distance;
 
-  @NotNull
-  private int expectedTime;
+  private int time;
+
+  private RouteStatus routeStatus;
 }


### PR DESCRIPTION
## 💡 이슈
resolve #69 

## 🤩 개요
delivery-service create api 분리

## 🧑‍💻 작업 사항
- 배송 생성시 배송경로가 함께 생성되던 api를 배송 생성과 배송경로 생성으로 분리
- 기능 분리로 생기는 dto 생성 및 수정, 삭제
- 배송과 배송경로의 데이터가 정상적으로 동기화되지 않아 응답 객체에서의 id값이 null로 반환되는 오류 발생하여 해결
  - subList를 사용하여 새로 추가된 경로만 정확히 추출
  - delivery.getRoutes()로 저장된 경로를 가져와 id가 null이 아닌 상태로 반환
  - JPA의 영속성 컨텍스트와 @OneToMany 관계를 활용

## 📖 참고 사항
